### PR TITLE
remove codesponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/Kq6Sn61hju7cqQu5xbQPq1eN/AangMonopolyDumbledore8/python-psychotherapist'>
-  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/Kq6Sn61hju7cqQu5xbQPq1eN/AangMonopolyDumbledore8/python-psychotherapist.svg' />
-</a>
+
 
 # python-psychotherapist
 Revenue is split between the current three contributors depending on how many commits each person makes.


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8